### PR TITLE
Update octane-ready.md

### DIFF
--- a/teaching-materials/octane-ready.md
+++ b/teaching-materials/octane-ready.md
@@ -4,33 +4,39 @@ Octane is Ember's first edition! It introduces some exciting new features and pa
 
 ## Make a decision - Octane-ready vs 100% Octane?
 
-If your addon is used by apps that are versions less than 3.15, you should work to make your addon "Octane ready," which means it is backwards compatible for use in apps v3.4 or higher, and also works great in Octane apps (3.15 or higher).
-"Octane ready" steps are recommended for all public, open source addons that existed before 3.15.
+If your addon is used by apps that are versions less than 3.13, you should work to make your addon "Octane ready," to continue to work in those older apps but also work in apps that have adopted Octane.
+"Octane ready" steps are recommended for all public, open source addons that existed before the official Octane release in 3.15.
 
 If your addon does not need to work for older versions of Ember, such as an addon that is used privately by your company and you use all Octane apps, you can make a 100% Octane addon.
 
 ### A backwards-compatible, Octane-ready app:
 
-- Works in Ember apps that are within the active LTS (long term support) range, i.e. 3.4 or later 
-- Does _not_ use Glimmer Components (`import Component from '@glimmer/component'`)
+- Works in Ember apps that are within the active LTS (long term support) range, i.e. 3.12 and 3.16.
 - Does _not_ use `@tracked` (`import { tracked } from '@glimmer/tracking'`)
 - Does _not_ use template-only components (every component `.hbs` file must have a corresponding `.js` file
-- Does _not_ use template co-location. This means that all templates should go in `addon/templates/components/` and `app/templates/components`, not `addon/components` and `app/components`
+- Does _not_ use template co-location without the `setComponentTemplate` polyfill. This means that all templates should go in `addon/templates/components/` and `app/templates/components`, not `addon/components` and `app/components`
 - May optionally use jQuery, if it is installed with the `@ember/jquery` package and used like `import $ from '@ember/jquery'`
 - Does _not_ use `this.$` or `Ember.$`. These are known as jQuery integration APIs.
-- Has `ember-try.js` tests for all active LTS (long term support) versions of Ember, plus versions 3.13 and higher
+- Has `ember-try.js` tests for all active LTS (long term support) versions of Ember, plus the current release.
 - If it uses Observers, they are marked `aysnc: true`, and the addon includes the async observers polyfill
 - May optionally use the latest versions of `ember-source`, `ember/data`, etc. in its `package.json` 
 
-To be very clear, if you use any features from `@glimmer`, template-only components, or template co-location, apps with versions <3.15 will not be able to use your addon!
+To be very clear, if you use `@tracked` from `@glimmer`, template-only components, or template co-location, apps with versions <3.15 will not be able to use your addon!
 
 ### A 100% Octane addon
 
-- Only works in apps with versions 3.15 or higher
+- Only works in apps with versions 3.13 or higher
 - Has the same configuration, packages, and features as an Octane app
-- May optionally use `@glimmer/component` and `@glimmer/tracking`
+- May optionally use `@glimmer/tracking`
+- Does not use `computed`s
+- Does not provide `@ember/components`. Uses `@glimmer/component` if creating components.
+- Does not use mixins.
+- Uses colocation.
+- Does not use observers.
+- Does not use `get` and `set` unless needed to interact with an older-style addon.
+- Does _not_ use `this.$` or `Ember.$`. These are known as jQuery integration APIs.
 - May optionally use jQuery, if it is installed with the `@ember/jquery` package and used like `import $ from '@ember/jquery'`
-- Has `ember-try.js` tests for versions 3.15 on up, only. Tests for lower versions will not pass.
+- Has `ember-try.js` tests for versions 3.13 on up, only. Tests for lower versions will not pass if using `@glimmer/tracking` (no polyfill) or other features when not providing polyfills.
 
 ## Optional syntax and linting improvements
 


### PR DESCRIPTION
Fill out more info. Update versions to indicate earliest octane version (earliest `@glimmer/tracking` version support), reflect the versions that will be out by the time we give this workshop.

Some pedantic wording changes